### PR TITLE
chore: standardize GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - name: Check super-linter
-        uses: github/super-linter@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # 7
+        uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # 8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-      - uses: reviewdog/action-misspell@e7ea17f144822818706c7e579de7927d59384575 # 1.27.0
+      - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # 1.27.0
         with:
           github_token: ${{ secrets.github_token }}
   check-spellcheck:


### PR DESCRIPTION
## Summary
- standardize pinned GitHub Actions versions in lint/linter, spellcheck, and update workflows
- align workflow action references with the latest owner-wide conventions
- preserve each repository's existing workflow behavior and repository-specific validations
